### PR TITLE
Make highlight groups for virtual text easily configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ require("neige").setup({
         success = "✓",
         loading = "🗘",
     },
+    hl = {
+        failure = "DiagnosticError",
+        success = "DiagnosticInfo",
+        loading = "DiagnosticInfo",
+    },
     split = "vnew",
 })
 ```

--- a/lua/neige/init.lua
+++ b/lua/neige/init.lua
@@ -222,6 +222,11 @@ local M = {
         success = "✓",
         loading = "🗘",
     },
+    hl = {
+        failure = "DiagnosticError",
+        success = "DiagnosticInfo",
+        loading = "DiagnosticInfo",
+    },
     load_revise = false,
     split = "vnew",
     chan = nil,
@@ -414,7 +419,7 @@ function M._send_code(opts, code)
         line_num = opts.line_num,
         run_id = M.run_id,
         append = false,
-        hl = "DiagnosticInfo",
+        hl = M.hl.loading,
         text = "",
         icon = M.icons.loading,
     })
@@ -438,10 +443,10 @@ function M._send_code(opts, code)
     local success = res[1]
     local repr = res[2]
 
-    local hl = "DiagnosticInfo"
+    local hl = M.hl.success
     local icon = M.icons.success
     if not success then
-        hl = "DiagnosticError"
+        hl = M.hl.failure
         icon = M.icons.failure
     end
 


### PR DESCRIPTION
This PR defines variables for the virtual text's highlight groups as is done for the other default options, thus making it more easily changable for the user. Kept the highlight groups as they were hardcoded before.

Also adjusted the default options code listing in the README.