### PR TITLE
Improve code evaluation: skip inline comments

### DIFF
--- a/lua/neige/init.lua
+++ b/lua/neige/init.lua
@@ -139,6 +139,13 @@ local function extract_nodes(opts)
     if node == nil then
         print("error: cannot get node at cursor")
         return nil
+	elseif node:type() == "source_file" then
+		print("error: cursor not on valid node")
+
+		local row, _ = table.unpack(vim.api.nvim_win_get_cursor(winnr))
+		vim.api.nvim_win_set_cursor(winnr, { row, 0 })
+
+		return nil
     end
     local parent = node:parent()
     while not toplevel_node(node, ft) do

--- a/lua/neige/init.lua
+++ b/lua/neige/init.lua
@@ -384,13 +384,18 @@ function M.send_command(opts)
         end
     end
 
-    local thread = coroutine.wrap(M._send_code)
-    local run_id = thread({
-        bufnr = bufnr,
-        line_num = line_num,
-        before_eval_fn = before_eval_fn,
-    }, code)
-    M.runs[run_id] = thread
+	local thread = coroutine.wrap(M._send_code)
+	local run_id = thread({
+		bufnr = bufnr,
+		line_num = line_num,
+		before_eval_fn = before_eval_fn,
+	}, code)
+    -- skip inline comments instead of evaluating them
+    if maybe_next:type() == "line_comment" then
+        local row, col, _ = maybe_next:end_()
+        vim.api.nvim_win_set_cursor(0, { row + 2, 0 })
+    end
+		M.runs[run_id] = thread
 end
 
 function M._send_code(opts, code)

--- a/lua/neige/init.lua
+++ b/lua/neige/init.lua
@@ -139,13 +139,13 @@ local function extract_nodes(opts)
     if node == nil then
         print("error: cannot get node at cursor")
         return nil
-	elseif node:type() == "source_file" then
-		print("error: cursor not on valid node")
+    elseif node:type() == "source_file" then
+        print("error: cursor not on valid node")
 
-		local row, _ = table.unpack(vim.api.nvim_win_get_cursor(winnr))
-		vim.api.nvim_win_set_cursor(winnr, { row, 0 })
+        local row, _ = table.unpack(vim.api.nvim_win_get_cursor(winnr))
+        vim.api.nvim_win_set_cursor(winnr, { row, 0 })
 
-		return nil
+        return nil
     end
     local parent = node:parent()
     while not toplevel_node(node, ft) do
@@ -391,18 +391,18 @@ function M.send_command(opts)
         end
     end
 
-	local thread = coroutine.wrap(M._send_code)
-	local run_id = thread({
-		bufnr = bufnr,
-		line_num = line_num,
-		before_eval_fn = before_eval_fn,
-	}, code)
+    local thread = coroutine.wrap(M._send_code)
+    local run_id = thread({
+        bufnr = bufnr,
+        line_num = line_num,
+        before_eval_fn = before_eval_fn,
+    }, code)
     -- skip inline comments instead of evaluating them
     if maybe_next:type() == "line_comment" then
         local row, col, _ = maybe_next:end_()
         vim.api.nvim_win_set_cursor(0, { row + 2, 0 })
     end
-		M.runs[run_id] = thread
+    M.runs[run_id] = thread
 end
 
 function M._send_code(opts, code)


### PR DESCRIPTION
This will skip code evaluation if it finds the next node to be an inline comment. This fixes the issue of accidentally hiding the code evaluation result that is printed with VirtualText if an inline comment follows the code in the same line.

This is EXPERIMENTAL and should be tested more before merging. I've tried on multiple files of different code formatting and commenting behaviour and it worked well for me. WIP for #3 

