### PR TITLE
advanced visual selection evaluation

### DIFF
--- a/lua/neige/init.lua
+++ b/lua/neige/init.lua
@@ -351,12 +351,23 @@ function M.send_visual_selection(opts)
     if col_end == 2147483647 then
         col_end = -1
     end
-    local code = vim.api.nvim_buf_get_text(bufnr, row_start, col_start, row_end, col_end, {})
 
-    return M._send_code({
-        bufnr = bufnr,
-        line_num = row_end,
-    }, code)
+    local row_diff = row_end - row_start
+    for i = 0,row_diff do
+        local code = vim.api.nvim_buf_get_text(
+            bufnr, row_start + i, col_start, row_start + i, col_end, {}
+        )
+        -- strips inline comments with and without preceding space in the line
+        code[1] = string.gsub(unpack(code), "%s*#.*", "")
+
+        local row = row_start + i
+        local thread = coroutine.wrap(M._send_code)
+        run_id = thread({
+            bufnr = bufnr,
+            line_num = row,
+        }, code)
+        M.runs[run_id] = thread
+    end
 end
 
 -- Extract the node under the cursor and sends it to the Julia process for evaluation


### PR DESCRIPTION
This PR starts work on the visual selection feature. I got it to work in theory, if a bunch of rows are selected in line-based visual selection (`"V"`) the evaluator will step through them and evaluate them one by one, placing the respective VirtualText next to the line.

This is even better than the VSCode implementation, which will only place a success or failure VirtualText at the end of the visual selection range and not give the per-line eval results like this implementation does.

In practice there is one issue though: If an evaluation happens while the prior evaluation is still running (which can happen for example with an assignment node that has very large multi-dimensional arrays) the evaluation gets interrupted and will hang and no further evaluations can be made unless the plugin is reset by restarting nvim. The same happens with visual-line evaluations, because the evaluator steps through the lines those will get evaluated almost instantaneously. Even putting in sleeps doesn't help for some reason, maybe I am doing it wrong though.

Enabling the debug logging in the Julia process helps get some insight:
For a normal, valid eval there are three debug events:
1. eval-fetch sending the node to Julia
2. eval reply from Julia
3. result from lua

At this point in time I am not too sure what the third event does/signals or is relevant to.
When an eval is triggered too shortly after a prior one, the third event does not get triggered for some reason.
To add, instead of the following debug output for a valid eval:

```c = Neovim.NvimClient{Base.PipeEndpoint}(Base.PipeEndpoint(RawFD(19) paused, 28 bytes waiting), Base.PipeEndpoint(RawFD(19) paused, 28 bytes waiting), 6, 6, Dict{Int64, Distributed.RemoteChannel}(), Task (runnable) @0x00007fc36d1a9460)```

an interrupted eval will have the following:

```c = Neovim.NvimClient{Base.PipeEndpoint}(Base.PipeEndpoint(RawFD(19) paused, 0 bytes waiting), Base.PipeEndpoint(RawFD(19) paused, 0 bytes waiting), 6, 7, Dict{Int64, Distributed.RemoteChannel}(6 => Distributed.RemoteChannel{Channel{Any}}(1, 1, 7)), Task (runnable) @0x00007fc36d1a9460)```

Note the last part, I think those `RemoteChannel`'s might be getting nested and that is what is causing the interruption?

Once that is fixed visual-line evaluations should work great!

Character-based visual selection (`"v"`) already works well for evaluating specific snippets of code on a single line.

Marking as Draft for now due to the visual-line bug. Maybe you have an idea on how to fix this? Again, not familiar with Neovim.jl.